### PR TITLE
Implement map-based flight search mode

### DIFF
--- a/world-app/backend/flight-service/app.py
+++ b/world-app/backend/flight-service/app.py
@@ -187,7 +187,15 @@ def nearest_airports():
     results = []
     for a in airports:
         dist = haversine(lat, lon, a["lat"], a["lon"])
-        results.append({"code": a["code"], "name": a["name"], "distance_km": dist})
+        results.append(
+            {
+                "code": a["code"],
+                "name": a["name"],
+                "lat": a["lat"],
+                "lon": a["lon"],
+                "distance_km": dist,
+            }
+        )
 
     results.sort(key=lambda x: x["distance_km"])
     return jsonify({"airports": results[:n]})

--- a/world-app/src/app/pages/flight-search/flight-search.component.css
+++ b/world-app/src/app/pages/flight-search/flight-search.component.css
@@ -10,6 +10,25 @@ app-map {
   height: 100%;
 }
 
+.interactive-button {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+  background: var(--blue4);
+  color: var(--white);
+  border: none;
+  padding: 8px 12px;
+  border-radius: 0.5em;
+  cursor: pointer;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.interactive-button:hover {
+  background: var(--blue3);
+}
+
 .dropdown-container {
   position: relative;
   display: inline-block;

--- a/world-app/src/app/pages/flight-search/flight-search.component.html
+++ b/world-app/src/app/pages/flight-search/flight-search.component.html
@@ -1,5 +1,7 @@
 <div class="container">
-    <app-map [toolbarMode]="'flight'" (flightSearchRequested)="openFlightSearch()"></app-map>
+    <app-map [toolbarMode]="'flight'"
+             (flightSearchRequested)="openFlightSearch()"
+             (flightPinsSelected)="onFlightPinsSelected($event)"></app-map>
 
     <!-- Flug-Suchformular -->
     <div class="flight-search-overlay" *ngIf="flightFormVisible" (click)="closeFlightSearch()">

--- a/world-app/src/app/pages/flight-search/flight-search.component.html
+++ b/world-app/src/app/pages/flight-search/flight-search.component.html
@@ -2,25 +2,28 @@
     <app-map [toolbarMode]="'flight'"
              (flightSearchRequested)="openFlightSearch()"
              (flightPinsSelected)="onFlightPinsSelected($event)"></app-map>
+    <button class="interactive-button" (click)="startInteractiveMode()">Interaktive Suche</button>
 
     <!-- Flug-Suchformular -->
     <div class="flight-search-overlay" *ngIf="flightFormVisible" (click)="closeFlightSearch()">
         <div class="flight-popup-container" (click)="$event.stopPropagation()">
             <div class="flight-search-box">
             <h3>Flugsuche</h3>
-            <form (ngSubmit)="searchFlights()">
+            <form (ngSubmit)="interactiveMode ? beginPointSelection() : searchFlights()">
+            <div *ngIf="!interactiveMode">
             <label>Von
                 <input [(ngModel)]="flightOrigin" name="origin" required
                        (ngModelChange)="clearError('origin')"
-                       [ngClass]="{ 'input-error': formErrors.origin }" 
+                       [ngClass]="{ 'input-error': formErrors.origin }"
                        placeholder="IATA-Code eintragen (z.B. FRA)"/>
             </label>
             <label>Nach
                 <input [(ngModel)]="flightDestination" name="destination" required
                        (ngModelChange)="clearError('destination')"
-                       [ngClass]="{ 'input-error': formErrors.destination }" 
+                       [ngClass]="{ 'input-error': formErrors.destination }"
                        placeholder="IATA-Code eintragen (z.B. JFK)"/>
             </label>
+            </div>
             <label>Datum
                 <input type="date" [(ngModel)]="flightDate" name="date" required
                        (ngModelChange)="clearError('date')"
@@ -45,6 +48,7 @@
             <label>Kinder
                 <input type="number" [(ngModel)]="flightChildren" name="children" min="0" />
             </label>
+            <div *ngIf="!interactiveMode">
             <label>
                 <input type="checkbox" [(ngModel)]="autoIata" name="autoIata" /> Automatische IATA-Suche
             </label>
@@ -53,15 +57,17 @@
                 placeholder="z. B. Stuttgart"/>
             </label>
             <button type="button" (click)="findAirportCode(airportNameSearch)">IATA-Code suchen</button>
+            </div>
             <div *ngIf="foundIataCodes.length">Gefundene Codes: {{ foundIataCodes.join(', ') }}</div>
             <div *ngIf="iataSearchError" class="flight-error">{{ iataSearchError }}</div>
             <div *ngIf="bookingError" class="flight-error">{{ bookingError }}</div>
             <button type="submit" [disabled]="isLoading">
-                Suchen
+                {{ interactiveMode ? 'Punkte wählen' : 'Suchen' }}
                 <span *ngIf="isLoading" class="loading-spinner"></span>
             </button>
-            <button type="button" (click)="openBookingPage()">Direkt zur Buchungsseite</button>
+            <button *ngIf="!interactiveMode" type="button" (click)="openBookingPage()">Direkt zur Buchungsseite</button>
             <button type="button" (click)="resetFlightSearch()">Zurücksetzen</button>
+            <button *ngIf="interactiveMode" type="button" (click)="cancelInteractiveMode()">Abbrechen</button>
             <button type="close" (click)="closeFlightSearch()">Schließen</button>
             </form>
             </div>


### PR DESCRIPTION
## Summary
- add airport CSV search helpers and `/nearest-airports` endpoint to flight service
- enable map to mark two flight points and emit coordinates
- allow FlightSearch page to use map points to auto search nearby airports and flights
- hook new output into flight search HTML

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624bd68250832f8c59a9c446b618ea